### PR TITLE
fix(css): apply theme colors during PDF/PNG/PPTX export

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -21,8 +21,13 @@
 }
 
 /* ℹ️ #app increases the specificity of .dark selector from upstream layout styles  */
+/* ℹ️ Target `.slidev-slide-content`/`.print-slide-container` instead of `#slide-content`,
+   since the id is only set on the "main" slide in the live viewer and is absent
+   during PDF/PNG/PPTX export and /print, where PrintSlideClick.vue renders slides
+   with `.print-slide-container` instead. Both classes cover viewer and export alike. */
 #app {
-  #slide-content {
+  .slidev-slide-content,
+  .print-slide-container {
 
     --at-apply: text-$foreground bg-$background !important;
 


### PR DESCRIPTION
After investigation it turns out `@slidev/client` only assigns `id="slide-content"` to the current slide's `SlideContainer.vue` when it is the "main" slide (`isMain === true`) in the live viewer. 

During PDF/PNG/PPTX export and the `/print` route, every slide is rendered by `PrintSlideClick.vue` instead, whose wrapper carries a different class - `print-slide-container`, with the client's own default background/foreground - so `#slide-content` never existed there and none of the rule ever applied to exported output.
   
`.slidev-slide-content` is always present on `SlideContainer.vue`, so listing both classes covers the live viewer (incl. slide transition states) and export alike.

Fixes #4